### PR TITLE
adds sass-rails

### DIFF
--- a/lib/activeadmin/medium_editor/engine.rb
+++ b/lib/activeadmin/medium_editor/engine.rb
@@ -1,3 +1,4 @@
+require 'sass-rails'
 require 'active_admin'
 
 module ActiveAdmin


### PR DESCRIPTION
Hi I was having an issue with the importing the medium_editor css files as per the instructions.

I was getting sass load path errors when doing this

```@import 'activeadmin/medium_editor_input';```

Changing it to this 
```@import 'activeadmin/medium_editor_input.css';```

got rid of the sass errors but then in the browser I kept getting 404s.

I came across this issue in the font-awesome-rails repo that was similar. It looks like their is an issue with dependencies and engines. (Didn't read the article yet, But the solution suggested seemed easy enough to require sass-rails in the engine). 

Let me know what you think and how I can help.


